### PR TITLE
Fix Staging and Production Endpoint Selection

### DIFF
--- a/src/LetsEncrypt/Extensions.cs
+++ b/src/LetsEncrypt/Extensions.cs
@@ -32,6 +32,7 @@ namespace LetsEncrypt
                 x.AccountKey = options.AccountKey;
                 x.EncryptionPassword = options.EncryptionPassword;
                 x.DaysBefore = options.DaysBefore;
+                x.UseStagingServer = options.UseStagingServer;
             });
 
             var selector = new CertificateSelector(options);

--- a/src/LetsEncrypt/LetsEncryptOptions.cs
+++ b/src/LetsEncrypt/LetsEncryptOptions.cs
@@ -38,10 +38,10 @@ namespace LetsEncrypt
         /// </summary>
         public bool UseStagingServer
         {
-            get => AcmeServer == WellKnownServers.LetsEncryptStaging;
+            get => AcmeServer == WellKnownServers.LetsEncryptStagingV2;
             set => AcmeServer = value
-                    ? WellKnownServers.LetsEncryptStaging
-                    : WellKnownServers.LetsEncrypt;
+                    ? WellKnownServers.LetsEncryptStagingV2
+                    : WellKnownServers.LetsEncryptV2;
         }
 
         /// <summary>


### PR DESCRIPTION
As per the documentation, consumers of the middleware can switch between the Production and Staging ACME endpoints for LetsEncrypt. Unfortunately, setting ``LetsEncryptOptions.UseStagingServer`` takes no effect as the IHostedService will always use the Production endpoint regardless of the option's setting.

This pull request correctly implements the switch between Staging and Production endpoints.